### PR TITLE
Added --host parm and changed CMD into ENTRYPOINT exec form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ EXPOSE 8080 25482
 
 WORKDIR /opt/OmniDB-${OMNIDB_VERSION}/OmniDB
 
-CMD python3 omnidb-server.py -p 8080 -d /etc/omnidb
+ENTRYPOINT ["python3", "omnidb-server.py", "--host=0.0.0.0", "--port=8080", "-d", "/etc/omnidb"]


### PR DESCRIPTION
I added the --host param because OmniDB starts by default on 127.0.0.1, whereas it needs to bind on 0.0.0.0 to be accessible from outside.