### PR TITLE
Add support for .my.cnf and .pgpass files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN apk add --no-cache --virtual .build-deps curl unzip g++ python3-dev \
       && find /usr/local -name '*.a' -delete \
       && addgroup -S omnidb && adduser -S omnidb -G omnidb \
       && chown -R omnidb:omnidb /opt/OmniDB-${OMNIDB_VERSION} \
-      && chown -R omnidb:omnidb /etc/omnidb
+      && chown -R omnidb:omnidb /etc/omnidb \
+      && ln -s /etc/omnidb/.my.cnf /home/omnidb/.my.cnf \
+      && ln -s /etc/omnidb/.pgpass /home/omnidb/.pgpass
 
 USER omnidb
 


### PR DESCRIPTION
Add symbolic links for .my.cnf and .pgpass files to support providing passwords for MySQL, Maria and PostgreSQL databases.

MySQL and MariaDB Format (**.my.cnf**):
```
[client]
user = username
password = password
host = address
```

PostgreSQL Format (**.pgpass**):
```
hostname:port:database:user:password
```